### PR TITLE
Atomic RoundRobin strategy

### DIFF
--- a/lib/ecto_facade/algorithms/roundrobin.ex
+++ b/lib/ecto_facade/algorithms/roundrobin.ex
@@ -18,10 +18,9 @@ defmodule EctoFacade.Algorithms.Roundrobin do
     end
 
     def get_next_repo() do
-      [current_repo | repos_without_current] = Agent.get(__MODULE__, & &1)
-      new_repos = repos_without_current ++ [current_repo]
-      Agent.update(__MODULE__, fn _ -> new_repos end)
-      current_repo
+      Agent.get_and_update(__MODULE__, fn [current_repo | other_repos] ->
+        {current_repo, other_repos ++ [current_repo]}
+      end)
     end
   end
 end


### PR DESCRIPTION
Fun project! I was interested in how you implemented it and did a readthrough on the code.
While doing so, I noticed that the round robining is implemented by using a list as a stack-based queue. I'm sure that the number of repo's anyone will be using will be quite small so the cost of doing so will be hardly anything, but maybe it'll add up to do that inside the requesting processes instead of in the Storage process.
Additionally, calling `get` and then `update` is non-atomic, so it's possible that concurrent requests will return the same Repo rather than truling cycling through them!